### PR TITLE
Enabling extension to find .env anywhere and use that location as root

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,11 @@ import { createStatusBar } from "./statusBar";
 export async function activate({ subscriptions }: vscode.ExtensionContext) {
   // Extension activation event will trigger only on a workspace with ".env" file in it,
   // so we can assert that workspace folders are not undefined
-  const fsHandler = new FileSystemHandler(vscode.workspace.workspaceFolders!);
+  const fsHandler = await vscode.workspace.findFiles('**/.env', undefined, 1).then(results => {
+    const envFile = results[0];
+    return new FileSystemHandler(vscode.workspace.workspaceFolders!, envFile);
+  });
+
   fsHandler.backupEnvCurrentFile();
 
   const statusBar = await createStatusBar(fsHandler);

--- a/src/fsHandler.ts
+++ b/src/fsHandler.ts
@@ -15,11 +15,11 @@ export class FileSystemHandler {
 
   private globOptions: globTypes.IOptions;
 
-  constructor(workspaceFolders: vscode.WorkspaceFolder[]) {
+  constructor(workspaceFolders: vscode.WorkspaceFolder[], env: vscode.Uri) {
     this.workspaceFolder = workspaceFolders[0];
-    this.root = this.workspaceFolder.uri.fsPath;
-    this.rootEnvFile = vscode.Uri.parse(`${this.root}${path.sep}.env`);
-    this.rootBackupEnvFile = vscode.Uri.parse(`${this.root}${path.sep}${BACKUP_FILE_NAME}.env`);
+    this.rootEnvFile = env;
+    this.root = env.fsPath.replace('.env', '');
+    this.rootBackupEnvFile = vscode.Uri.parse(`${this.root}${BACKUP_FILE_NAME}.env`);
 
     this.globOptions = {
       cwd: this.root,
@@ -46,7 +46,7 @@ export class FileSystemHandler {
    * findCurrentEnvFile
    */
   public findCurrentEnvFile() {
-    return glob(`${path.sep}.env`, this.globOptions);
+    return glob(`${this.root}.env`, this.globOptions);
   }
 
   /**
@@ -102,7 +102,7 @@ export class FileSystemHandler {
    */
   public async backupEnvCurrentFile() {
     const backupEnvExists =
-      (await this.findFiles(`${path.sep}${BACKUP_FILE_NAME}.env`)).length !== 0;
+      (await this.findFiles(`${this.root}${BACKUP_FILE_NAME}.env`)).length !== 0;
     const envExists = (await this.findCurrentEnvFile()).length !== 0;
 
     if (!backupEnvExists && envExists) {


### PR DESCRIPTION
This extension is exactly what I've been looking for except that it only works if the env file is in root.

With this change I was able to make the extension look for any env file in the workdirectory and use the first file found as "root". Which is used for setting the location of backups