### PR TITLE
Update Readme.md to point to pinned discussion of m.workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Extension will not start if no target was found when the directory was first ope
 ### Will you support monorepos?
 
 I'd like to, but there are so many ways to structure a monorepo and so many approaches to handle targets and presets that I'm not sure how to even approach it.  
-If you'd like to help with an idea or join the discussion - you can do that [here](https://github.com/EcksDy/vscode-env-switcher/issues/17).
+If you'd like to help with an idea or join the discussion - you can do that in [Discussing a UI solution for multiroot/monorepo workspaces](https://github.com/EcksDy/vscode-env-switcher/issues/41).
 
 ### How can I turn off the warning in the status bar?
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Extension will not start if no target was found when the directory was first ope
 ### Will you support monorepos?
 
 I'd like to, but there are so many ways to structure a monorepo and so many approaches to handle targets and presets that I'm not sure how to even approach it.  
-If you'd like to help with an idea or join the discussion - you can do that in [Discussing a UI solution for multiroot/monorepo workspaces](https://github.com/EcksDy/vscode-env-switcher/issues/41).
+If you'd like to help with an idea or join the discussion you can do that in:
+- [Support multiroot workspaces](https://github.com/EcksDy/vscode-env-switcher/issues/17)
+- [Discussing a UI solution for multiroot/monorepo workspaces](https://github.com/EcksDy/vscode-env-switcher/issues/41).
 
 ### How can I turn off the warning in the status bar?
 


### PR DESCRIPTION
Made a small tweak to readme to point to the pinned discussion of m.workspaces rather then the original issue. 

\+ changed the wording to be more friendly to accessibility readers. 